### PR TITLE
[bugfix] Defaut 'repo' to empty object in libp2p config

### DIFF
--- a/src/components/libp2p.js
+++ b/src/components/libp2p.js
@@ -19,7 +19,7 @@ module.exports = ({
   options = {},
   peerId,
   multiaddrs = [],
-  repo,
+  repo = {},
   keychainConfig = {},
   config = {},
 }) => {


### PR DESCRIPTION
Signed-off-by: Allen Muncy [allen.w.muncy@gmail.com](allen.w.muncy@gmail.com)

## Pull request checklist
* [x]  Tests for the changes have been added (for bug fixes / features), and are passing

* [x]  Docs have been reviewed and added / updated if needed (for bug fixes / features)

* [ ]  Build (`npm run types`) was run locally and any changes were pushed

* [x]  Lint (`npm run lint`) has passed locally and any fixes were made for failure

 ## Pull request type
 
Please check the type of change your PR introduces:
 
* [x]  Bugfix

* [ ]  Feature

* [ ]  Code style update (formatting, renaming)
 
* [ ]  Refactoring (no functional changes, no api changes)

* [ ]  Build related changes
* [ ]  Documentation content changes
 
* [ ]  Other (please describe):

## What is the current behavior?

If `repo` is not specified in config object, an error is thrown. This means the example in the README.md does not work.

## What is the new behavior?

`repo` option for config defaults to an empty object instead of undefined.

## Does this introduce a breaking change?

* [ ]  Yes
* [x]  No

